### PR TITLE
pypi publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: publish to pypi
+on:
+  push:
+    branches:
+      - master
+      - pypi-publishing
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+          cache: poetry
+      - name: Build
+        run: poetry build
+      - name: Publish
+        run: poetry publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: poetry
       - name: Build
         run: poetry build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
-name: publish to pypi
+name: Release to pypi
 on:
   push:
     branches:
       - master
-      - pypi-publishing
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
-name: Tests
+name: Test
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyler-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Skyler's toolbox of handy CLI utils"
 authors = ["bouldersky <skyarnold1@me.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "skyler-cli"
 version = "0.1.0"
-description = ""
+description = "Skyler's toolbox of handy CLI utils"
 authors = ["bouldersky <skyarnold1@me.com>"]
 readme = "README.md"
 packages = [{include = "skyler_cli", from = "src"}]


### PR DESCRIPTION
- move cli logic into cli package to prep for seperate core package
- bootstrap bashrc
- fix cli main path
- add description
- add ci to publish package with poetry
- quote python version
- set poetry pypi token
- bump version
- rename workflows
